### PR TITLE
Move off of images hosted on DockerHub

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -17,20 +17,20 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Release notes
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: publish-release-notes-to-github
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       - name: Zulip
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: send-announcement-to-pony-zulip
         env:
           ZULIP_API_KEY: ${{ secrets.ZULIP_RELEASE_API_KEY }}
           ZULIP_EMAIL: ${{ secrets.ZULIP_RELEASE_EMAIL }}
       - name: Last Week in Pony
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: add-announcement-to-last-week-in-pony
         env:
@@ -48,14 +48,14 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Rotate release notes
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: rotate-release-notes
         env:
           GIT_USER_NAME: "Sean T.  Allen"
           GIT_USER_EMAIL: "sean@seantallen.com"
       - name: Delete announcement trigger tag
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: delete-announcement-tag
         env:

--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -9,7 +9,7 @@ jobs:
     name: Verify in release mode on Linux with most recent ponyc
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
     steps:
       - uses: actions/checkout@v1
       - name: Test with the most recent ponyc
@@ -19,7 +19,7 @@ jobs:
     name: Verify in debug mode on Linux with most recent ponyc
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder:latest
     steps:
       - uses: actions/checkout@v1
       - name: Test with the most recent ponyc

--- a/.github/workflows/changelog-bot.yml
+++ b/.github/workflows/changelog-bot.yml
@@ -15,7 +15,7 @@ jobs:
     name: Update CHANGELOG.md
     steps:
       - name: Update Changelog
-        uses: docker://ponylang/changelog-bot-action:0.3.5
+        uses: docker://ghcr.io/ponylang/changelog-bot-action:0.3.5
         with:
           git_user_name: "Sean T. Allen"
           git_user_email: "sean@seantallen.com"

--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Generate documentation and upload
-        uses: docker://ponylang/library-documentation-action:release
+        uses: docker://ghcr.io/ponylang/library-documentation-action:release
         with:
           site_url: "https://seantallen-org.github.io/msgpack/"
           library_name: "msgpack"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
     name: Verify CHANGELOG is valid
     runs-on: ubuntu-latest
     container:
-      image: ponylang/changelog-tool:release
+      image: ghcr.io/ponylang/changelog-tool:release
     steps:
       - uses: actions/checkout@v1
       - name: Verify CHANGELOG
@@ -30,7 +30,7 @@ jobs:
     name: Verify release mode on Linux with most recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder:release
     steps:
       - uses: actions/checkout@v1
       - name: Test with the most recent ponyc release
@@ -40,7 +40,7 @@ jobs:
     name: Verify debug mode on Linux with most recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-x86-64-unknown-linux-builder:release
     steps:
       - uses: actions/checkout@v1
       - name: Test with the most recent ponyc release

--- a/.github/workflows/prepare-for-a-release.yml
+++ b/.github/workflows/prepare-for-a-release.yml
@@ -22,28 +22,28 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Update CHANGELOG.md
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: update-changelog-for-release
         env:
           GIT_USER_NAME: "Sean T.  Allen"
           GIT_USER_EMAIL: "sean@seantallen.com"
       - name: Update VERSION
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: update-version-in-VERSION
         env:
           GIT_USER_NAME: "Sean T.  Allen"
           GIT_USER_EMAIL: "sean@seantallen.com"
       - name: Update version in README
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: update-version-in-README
         env:
           GIT_USER_NAME: "Sean T.  Allen"
           GIT_USER_EMAIL: "sean@seantallen.com"
       - name: Update corral.json
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: update-version-in-corral-json
         env:
@@ -65,7 +65,7 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Trigger artefact creation
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: trigger-artefact-creation
         env:
@@ -90,7 +90,7 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Add "unreleased" section to CHANGELOG.md
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: add-unreleased-section-to-changelog
         env:

--- a/.github/workflows/release-notes-reminder.yml
+++ b/.github/workflows/release-notes-reminder.yml
@@ -10,7 +10,7 @@ jobs:
     name: Prompt to add release notes
     steps:
       - name: Prompt to add release notes
-        uses: docker://ponylang/release-notes-reminder-bot-action:0.1.0
+        uses: docker://ghcr.io/ponylang/release-notes-reminder-bot-action:0.1.1
         env:
           API_CREDENTIALS: ${{ secrets.API_TOKEN }}
 

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -16,7 +16,7 @@ jobs:
     name: Update release notes
     steps:
       - name: Update
-        uses: docker://ponylang/release-notes-bot-action:0.3.6
+        uses: docker://ghcr.io/ponylang/release-notes-bot-action:0.3.7
         with:
           git_user_name: "Sean T. Allen"
           git_user_email: "sean@seantallen.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Validate CHANGELOG
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: pre-artefact-changelog-check
 
@@ -37,7 +37,7 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Generate documentation and upload
-        uses: docker://ponylang/library-documentation-action:release
+        uses: docker://ghcr.io/ponylang/library-documentation-action:release
         with:
           site_url: "https://seantallen-org.github.io/msgpack/"
           library_name: "msgpack"
@@ -58,7 +58,7 @@ jobs:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
       - name: Trigger
-        uses: ponylang/release-bot-action@0.6.1
+        uses: docker://ghcr.io/ponylang/release-bot-action:0.6.3
         with:
           entrypoint: trigger-release-announcement
         env:


### PR DESCRIPTION
Ponylang org is transitioning to GitHub Container Registry, new images will stop appearing on DockerHub soon and those that are there will stop being built.